### PR TITLE
Create fake env var for tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -65,6 +65,11 @@ module.exports = function(grunt) {
   grunt.loadTasks('tasks');
 
   // Default task.
-  grunt.registerTask('default', ['jshint','clean','copy','preprocess', 'nodeunit']);
+  grunt.registerTask('default', ['jshint','clean', 'fake-env', 'copy','preprocess', 'nodeunit']);
+
+  grunt.registerTask('fake-env', function() {
+    // create a fake env var for tests
+    process.env['FAKEHOME'] = '/Users/joverson';
+  });
 
 };

--- a/test/fixtures/test.html
+++ b/test/fixtures/test.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <h1><!-- @echo customOption --></h1>
-  <h1><!-- @echo HOME --></h1>
+  <h1><!-- @echo FAKEHOME --></h1>
   <h2><!-- @include include.txt --></h2>
 </body>
 </html>


### PR DESCRIPTION
Tests were dependent on a specific HOME environment setup. This caused tests to fail on systems where HOME is not defined or is set to a path other than `/Users/joverson`.
