### PR TITLE
Fixes #15 - Add tests demonstrating coffee-script support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,6 +18,10 @@ module.exports = function(grunt) {
         src : 'test/fixtures/test.js',
         dest : 'tmp/test.processed.js'
       },
+      coffee : {
+        src : 'test/fixtures/test.coffee',
+        dest : 'tmp/test.processed.coffee'
+      },
       deep : {
         src : 'test/fixtures/test.js',
         dest : 'tmp/deep/directory/structure/test.processed.js'

--- a/test/expected/test.processed.expected.coffee
+++ b/test/expected/test.processed.expected.coffee
@@ -1,0 +1,12 @@
+#global define
+
+define [], ->
+  "use strict"
+
+  
+  superExpensiveFunction()
+  
+
+  
+
+  !foobar!

--- a/test/fixtures/test.coffee
+++ b/test/fixtures/test.coffee
@@ -1,0 +1,14 @@
+#global define
+
+define [], ->
+  "use strict"
+
+  # @exclude NODE_ENV='production'
+  superExpensiveFunction()
+  # @endexclude
+
+  # @if NODE_ENV='production'
+  superExpensiveFunction()
+  # @endif
+
+  # @include include.txt

--- a/test/preprocess_test.js
+++ b/test/preprocess_test.js
@@ -51,6 +51,17 @@ exports['preprocess'] = {
     test.done();
 
   },
+  'preprocess coffee': function(test) {
+    test.expect(1);
+    var expected, actual;
+
+    expected = grunt.file.read('test/expected/test.processed.expected.coffee');
+    actual = grunt.file.read('tmp/test.processed.coffee');
+    test.equal(expected, actual, 'Files differ');
+
+    test.done();
+    
+  },
   'inline': function(test) {
     test.expect(2);
     var expected, actual;


### PR DESCRIPTION
In response to issue-15, I just did some quick investigating and I guess it's already supported in pre-process, so I thought it would be good to add some tests to show this.

There are some nicks in preprocess, particularly how whitespace preceding preprocessor comments is not removed, and this kind of sucks a little bit, even if it gets cleaned up during uglify
