### PR TITLE
Fixed bug generating target context when task options is undefined.

### DIFF
--- a/tasks/preprocess.js
+++ b/tasks/preprocess.js
@@ -25,7 +25,7 @@ function init(grunt) {
 
     var options = this.options();
 
-    var origOptions = grunt.config('preprocess').options;
+    var origOptions = grunt.config('preprocess').options || {};
 
     var context = _.extend({}, process.env, options.context || {}, origOptions.context || {});
 


### PR DESCRIPTION
Feature for merging task context into target context (#13) breaks the entire task if task options is undefined.
This simple change fixes that.
