### PR TITLE
Showing an explicit version of using `multifile`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,13 @@ preprocess : {
     dest : 'test/test.processed.html'
   },
   multifile : {
-    files : {
-      'test/test.processed.html' : 'test/test.html',
-      'test/test.processed.js'   : 'test/test.js'
-    }
+    files : [{
+      src : 'test/test.processed.html',
+      dest : 'test/test.html'
+    }, {
+      src : 'test/test.processed.js',
+      dest : 'test/test.js'
+    }]
   },
   inline : {
     src : [ 'processed/**/*.js' ],


### PR DESCRIPTION
Showing how to use `src` and `dest` explicitly, to avoid having the source overridden.

I've found that using

``` js
multifile : {
  files : {
    'test/test.processed.html' : 'test/test.html',
    'test/test.processed.js'   : 'test/test.js'
}
```

was overriding my src files, so I've changed the README to, imho, a safer version. It's worth pointing out that I did not have the `inline` flag set to `true`. 
Did I understand the behaviour correctly? If not I'm sorry and please close this.

Thanks for the work you did on this project.
