### PR TITLE
Add note about default value of NODE_ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Required to enable overwriting of source files
 Type: `Object`
 Default: `{}`
 
-The additional context on top of ENV that should be passed to templates
+The additional context on top of ENV that should be passed to templates. If NODE_ENV is not set, the task sets it to `development` by default.
 
 
 ## Example Usage


### PR DESCRIPTION
I don't think gulp-preprocess sets NODE_ENV by default; when I used gulp-preprocess I used `ifndef NOD_ENV`. So this threw me for a bit of a loop.